### PR TITLE
Issue 61

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -88,8 +88,8 @@ unique <- function(x) {
 #' @return Min-log-likelihood per person in the dataset.
 #' 
 #' @export 
-mll_rcpp <- function(data, parameters, ids, idx, cells) {
-    .Call('_predped_mll_rcpp', PACKAGE = 'predped', data, parameters, ids, idx, cells)
+mll_rcpp <- function(data, parameters, ids, idx, cells, sizes, summed) {
+    .Call('_predped_mll_rcpp', PACKAGE = 'predped', data, parameters, ids, idx, cells, sizes, summed)
 }
 
 psUtility <- function(a_preferred_speed, b_preferred_speed, preferred_speed, slowing_time, current_speed, goal_distance) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -84,8 +84,18 @@ unique <- function(x) {
 #' @param cells IntegerVector denoting the cell to which a participant has 
 #' moved at a given iteration. Order should conform to the order in the list of 
 #' the data.
+#' @param sizes IntegerVector containing the number of data points per person.
+#' Ignored if \code{summed} is \code{TRUE}.
+#' @param summed Boolean denoting whether to sum the min-log-likelihood to one
+#' value per person. If \code{TRUE}, you get the resulting summed 
+#' min-log-likelihood for each individual with a correction to avoid \code{-Inf}s.
+#' If \code{FALSE}, the function will instead return a list of vectors containing
+#' the raw likelihoods (not min-log-likelihoods!), allowing users to specify 
+#' their own corrections (if needed).
 #' 
-#' @return Min-log-likelihood per person in the dataset.
+#' @return Either named vector containing the summed min-log-likelihood 
+#' (\code{summed = TRUE}) or named list with vectors of raw likelihoods
+#' (\code{summed = FALSE}) per person in the dataset.
 #' 
 #' @export 
 mll_rcpp <- function(data, parameters, ids, idx, cells, sizes, summed) {

--- a/R/likelihood.R
+++ b/R/likelihood.R
@@ -108,42 +108,38 @@ mll <- function(data,
                         data$cell,
                         as.integer(table(data$id)),
                         summed)
-        
-        if(summed) {
-            MLL <- as.vector(MLL)
-        }
-        return(MLL)
-    }
-
-    # For each agent, loop over the unique participant id's 
-    MLL <- lapply(seq_along(ids), 
-                  function(i) {
-                      # Select the data for which the utilities should be computed
-                      selection <- data[data$id == ids[i], ]
+                        
+    } else {
+        # For each agent, loop over the unique participant id's 
+         MLL <- lapply(seq_along(ids), 
+                       function(i) {
+                           # Select the data for which the utilities should be computed
+                           selection <- data[data$id == ids[i], ]
   
-                      # Get the utilities for each cell based on the provided 
-                      # results
-                      L <- sapply(1:nrow(selection), 
-                                  function(j) {
-                                      V <- utility(selection[j, ], parameters[i, ], cpp = FALSE)
-
-                                      V <- V - max(V)
-                                      exp_V <- exp(V)
-                                      return(exp_V[selection$cell[j] + 1] / sum(exp_V))
-                                  })
+                           # Get the utilities for each cell based on the provided 
+                           # results
+                           L <- sapply(1:nrow(selection), 
+                                       function(j) {
+                                           V <- utility(selection[j, ], parameters[i, ], cpp = FALSE)
+     
+                                           V <- V - max(V)
+                                           exp_V <- exp(V)
+                                           return(exp_V[selection$cell[j] + 1] / sum(exp_V))
+                                       })
                       
-                      # Convert likelihoods to min-log-likelihood. 1 was added
-                      # to each likelihood to ensure that 0 probability will 
-                      # not lead to -Inf min-log-likelihood.
-                      if(summed) {
-                        return(-sum(log(1 + L)))
-                      } else {
-                        return(L)
-                      }
-                  })
+                           # Convert likelihoods to min-log-likelihood. 1 was added
+                           # to each likelihood to ensure that 0 probability will 
+                           # not lead to -Inf min-log-likelihood.
+                           if(summed) {
+                             return(-sum(log(1 + L)))
+                           } else {
+                             return(L)
+                           }
+                       })
+    }    
 
     if(summed) {
-        MLL <- as.vector(MLL)
+        MLL <- as.numeric(MLL)
     }
     names(MLL) <- ids 
     return(MLL)

--- a/benchmark/files/benchmark_likelihood.Rmd
+++ b/benchmark/files/benchmark_likelihood.Rmd
@@ -2,6 +2,8 @@
 
 ## mll
 
+### summed = TRUE
+
 ```{r likelihood mll, echo = FALSE, results = "asis"}
 
 # Read in the data to be used for the mll. Consists of one person with 2500 
@@ -37,6 +39,82 @@ bounded_rcpp <- (\() predped::mll(full_data, params_bounded, transform = FALSE, 
     rnd()
 
 real_rcpp <- (\() predped::mll(full_data, params_real, transform = TRUE, cpp = TRUE)) |>
+    test_times() |>
+    rnd()
+
+# Create the table
+tbl <- rbind(c("cpp = FALSE", 
+               bounded_r[2], 
+               paste0("[", bounded_r[1], ",", bounded_r[3], "]"), 
+               real_r[2], 
+               paste0("[", real_r[1], ",", real_r[3], "]")), 
+             c("cpp = TRUE", 
+               bounded_rcpp[2], 
+               paste0("[", bounded_rcpp[1], ",", bounded_rcpp[3], "]"), 
+               real_rcpp[2], 
+               paste0("[", real_rcpp[1], ",", real_rcpp[3], "]")))
+colnames(tbl) <- NULL
+
+# Write the caption
+caption <- paste0("Benchmark for the mll function. ",
+                  "In this benchmark, we use 100 datapoints of 10 different people. ",
+                  "We distinguish between providing parameters on the real axis ",
+                  "(transform = TRUE) or on the bounded scale of predped ", 
+                  "(transform = FALSE). ",
+                  "We also distinguish between using the R version of this ", 
+                  "function (cpp = FALSE) and the Rcpp version of this function ",
+                  "(cpp = TRUE).")
+
+tbl |>
+    knitr::kable(format = "latex", 
+                 align = "lll",
+                 caption = caption,
+                 longtable = FALSE,
+                 booktabs = TRUE,
+                 escape = FALSE,  
+                 position = "H" ) |>
+    kableExtra::add_header_above(c(" " = 1, "transform = FALSE" = 2, "transform = TRUE" = 2)) |>
+    print()
+
+```
+
+### summed = FALSE
+
+```{r likelihood mll, echo = FALSE, results = "asis"}
+
+# Read in the data to be used for the mll. Consists of one person with 2500 
+# samples.
+data <- readRDS(file.path("..", "tests", "testthat", "data", "data_mll_benchmark.Rds"))
+data <- data[data$id == "eqdyv", ]
+data <- data[1:100, ]
+
+full_data <- data 
+for(i in 1:9) {
+    data$id <- paste0("person_", i)
+    full_data <- rbind(full_data, data)
+}
+
+# Create parameters that fall on the real axis and parameters that fall on the 
+# bounded axis
+params_bounded <- predped::params_from_csv[["params_archetypes"]][1, -c(1:2)]
+params_real <- predped::to_unbounded(params_bounded, 
+                                     predped::params_from_csv[["params_bounds"]])
+
+# Do four tests, one distinguishing unbounded and bounded estimation and one
+# distinguishing R from Rcpp.
+bounded_r <- (\() predped::mll(full_data, params_bounded, transform = FALSE, cpp = FALSE, summed = FALSE)) |>
+    test_times() |>
+    rnd()
+
+real_r <- (\() predped::mll(full_data, params_real, transform = TRUE, cpp = FALSE, summed = FALSE)) |>
+    test_times() |>
+    rnd()
+
+bounded_rcpp <- (\() predped::mll(full_data, params_bounded, transform = FALSE, cpp = TRUE, summed = FALSE)) |>
+    test_times() |>
+    rnd()
+
+real_rcpp <- (\() predped::mll(full_data, params_real, transform = TRUE, cpp = TRUE, summed = FALSE)) |>
     test_times() |>
     rnd()
 

--- a/man/mll.Rd
+++ b/man/mll.Rd
@@ -11,6 +11,7 @@ mll(
   transform = TRUE,
   bounds = params_from_csv[["params_bounds"]],
   cpp = TRUE,
+  summed = FALSE,
   ...
 )
 }
@@ -38,12 +39,23 @@ in its first and second column respectively. Additionally, rownames should
 denote for which parameter a certain pair represents the bounds. Only used 
 when \code{transform = TRUE}. Defaults to the default bounds of \code{predped}.}
 
+\item{cpp}{Logical denoting whether to use the \code{\link[predped]{mll_rcpp}}
+function to compute the min-log-likelihood. Defaults to \code{TRUE}.}
+
+\item{summed}{Logical denoting whether to sum the min-log-likelihood to one
+value per person. If \code{TRUE}, you get the resulting summed 
+min-log-likelihood for each individual with a correction to avoid \code{-Inf}s.
+If \code{FALSE}, the function will instead return a list of vectors containing
+the raw likelihoods (not min-log-likelihoods!), allowing users to specify 
+their own corrections (if needed). Defaults to \code{FALSE}.}
+
 \item{...}{Additional arguments passed on to \code{\link[predped]{add_motion_variables}}.
 In a typical estimation situation, these motion variables should already be 
-in \code{data}.}
-}
-\value{
-Min-log-likelihood per person in the dataset.
+in \code{data}.
+
+ @return Either named vector containing the summed min-log-likelihood 
+(\code{summed = TRUE}) or named list with vectors of raw likelihoods
+(\code{summed = FALSE}) per person in the dataset.}
 }
 \description{
 Use data to compute the min-log-likelihood of choosing a given observed cell  

--- a/man/mll_rcpp.Rd
+++ b/man/mll_rcpp.Rd
@@ -4,38 +4,39 @@
 \alias{mll_rcpp}
 \title{Compute the min-log-likelihood}
 \usage{
-mll_rcpp(data, parameters, parameter_names, ids)
+mll_rcpp(data, parameters, ids, idx, cells, sizes, summed)
 }
 \arguments{
-\item{data}{Data.frame containing at least "id", "time", "x", "y", "goal_x",
-"goal_y", and "goal_id". If it does not have the utility variables yet, these
-will add them to the data.frame.}
+\item{data}{List containing data.frames to use in the estimation procedure.}
 
-\item{parameters}{Numeric vector or matrix containing the parameters to be 
-used. Should be specified in the same order as specified in 
-\code{"parameter_names"}. If a matrix, each row should contain parameters to 
-be estimated for each instance of "id" separately.}
+\item{parameters}{List containing the parameters to be used.
+Should be specified in the same order as specified in \code{"parameter_names"}.}
 
-\item{parameter_names}{Character vector containing the parameters that you 
-want to estimate. Defaults to all parameters defined in
-\code{\link[predped]{params_from_csv}}. Whenever not all parameters are used,
-the excluded parameters are assumed to have a value of 0.}
+\item{ids}{CharacterVector containing the names of the participants in the 
+data set.}
 
-\item{transform}{Logical denoting whether to transform the provided parameters
-from the real axis to the bounded scales imposed on the parameters within 
-\code{predped}. Defaults to \code{TRUE}.}
+\item{idx}{IntegerVector containing the index of the parameters to use to 
+evaluate a given row in the data. Note that this index uses C++ convention.
+Order should conform to the order in the list of the data.}
 
-\item{bounds}{Matrix containing the lower and upper bounds of the parameters
-in its first and second column respectively. Additionally, rownames should 
-denote for which parameter a certain pair represents the bounds. Only used 
-when \code{transform = TRUE}. Defaults to the default bounds of \code{predped}.}
+\item{cells}{IntegerVector denoting the cell to which a participant has 
+moved at a given iteration. Order should conform to the order in the list of 
+the data.}
 
-\item{...}{Additional arguments passed on to \code{\link[predped]{add_motion_variables}}.
-In a typical estimation situation, these motion variables should already be 
-in \code{data}.}
+\item{sizes}{IntegerVector containing the number of data points per person.
+Ignored if \code{summed} is \code{TRUE}.}
+
+\item{summed}{Boolean denoting whether to sum the min-log-likelihood to one
+value per person. If \code{TRUE}, you get the resulting summed 
+min-log-likelihood for each individual with a correction to avoid \code{-Inf}s.
+If \code{FALSE}, the function will instead return a list of vectors containing
+the raw likelihoods (not min-log-likelihoods!), allowing users to specify 
+their own corrections (if needed).}
 }
 \value{
-Min-log-likelihood per person in the dataset.
+Either named vector containing the summed min-log-likelihood 
+(\code{summed = TRUE}) or named list with vectors of raw likelihoods
+(\code{summed = FALSE}) per person in the dataset.
 }
 \description{
 Rcpp alternative to \code{\link[predped]{mll}}. Be wary: This version does 

--- a/man/utility_rcpp.Rd
+++ b/man/utility_rcpp.Rd
@@ -4,7 +4,7 @@
 \alias{utility_rcpp}
 \title{Utility}
 \usage{
-utility_rcpp(Data, parameters)
+utility_rcpp(data, parameters)
 }
 \arguments{
 \item{parameters}{Dataframe containing the parameters of the agent. Should 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -50,8 +50,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // mll_rcpp
-NumericVector mll_rcpp(List data, List parameters, CharacterVector ids, IntegerVector idx, IntegerVector cells);
-RcppExport SEXP _predped_mll_rcpp(SEXP dataSEXP, SEXP parametersSEXP, SEXP idsSEXP, SEXP idxSEXP, SEXP cellsSEXP) {
+List mll_rcpp(List data, List parameters, CharacterVector ids, IntegerVector idx, IntegerVector cells, IntegerVector sizes, bool summed);
+RcppExport SEXP _predped_mll_rcpp(SEXP dataSEXP, SEXP parametersSEXP, SEXP idsSEXP, SEXP idxSEXP, SEXP cellsSEXP, SEXP sizesSEXP, SEXP summedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -60,7 +60,9 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< CharacterVector >::type ids(idsSEXP);
     Rcpp::traits::input_parameter< IntegerVector >::type idx(idxSEXP);
     Rcpp::traits::input_parameter< IntegerVector >::type cells(cellsSEXP);
-    rcpp_result_gen = Rcpp::wrap(mll_rcpp(data, parameters, ids, idx, cells));
+    Rcpp::traits::input_parameter< IntegerVector >::type sizes(sizesSEXP);
+    Rcpp::traits::input_parameter< bool >::type summed(summedSEXP);
+    rcpp_result_gen = Rcpp::wrap(mll_rcpp(data, parameters, ids, idx, cells, sizes, summed));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -401,7 +403,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_predped_time_series_rcpp", (DL_FUNC) &_predped_time_series_rcpp, 2},
     {"_predped_unpack_trace_rcpp", (DL_FUNC) &_predped_unpack_trace_rcpp, 5},
     {"_predped_unique", (DL_FUNC) &_predped_unique, 1},
-    {"_predped_mll_rcpp", (DL_FUNC) &_predped_mll_rcpp, 5},
+    {"_predped_mll_rcpp", (DL_FUNC) &_predped_mll_rcpp, 7},
     {"_predped_psUtility", (DL_FUNC) &_predped_psUtility, 6},
     {"_predped_gaUtility", (DL_FUNC) &_predped_gaUtility, 3},
     {"_predped_caUtility", (DL_FUNC) &_predped_caUtility, 3},

--- a/tests/testthat/test_likelihood.R
+++ b/tests/testthat/test_likelihood.R
@@ -23,12 +23,12 @@ testthat::test_that("Computing the MLL works", {
     params_max$a_current_direction <- 2
 
     # Compute the min-log-likelihood for each of the parameters
-    best <- predped::mll(data, params, transform = FALSE)
+    best <- predped::mll(data, params, transform = FALSE, summed = TRUE)
 
-    min <- predped::mll(data, params_min, transform = FALSE)
-    q25 <- predped::mll(data, params_25, transform = FALSE)
-    q75 <- predped::mll(data, params_75, transform = FALSE)
-    max <- predped::mll(data, params_max, transform = FALSE)
+    min <- predped::mll(data, params_min, transform = FALSE, summed = TRUE)
+    q25 <- predped::mll(data, params_25, transform = FALSE, summed = TRUE)
+    q75 <- predped::mll(data, params_75, transform = FALSE, summed = TRUE)
+    max <- predped::mll(data, params_max, transform = FALSE, summed = TRUE)
     
     # Ideally, the mll of the generating parameters should be lower than the 
     # mll of other parameters. Test this assumption here.
@@ -70,12 +70,12 @@ testthat::test_that("Computing the MLL with conversion works", {
     params_max <- predped::to_unbounded(params_max, bounds)
 
     # Compute the min-log-likelihood for each of the parameters
-    best <- predped::mll(data, params, transform = TRUE)
+    best <- predped::mll(data, params, transform = TRUE, summed = TRUE)
 
-    min <- predped::mll(data, params_min, transform = TRUE)
-    q25 <- predped::mll(data, params_25, transform = TRUE)
-    q75 <- predped::mll(data, params_75, transform = TRUE)
-    max <- predped::mll(data, params_max, transform = TRUE)
+    min <- predped::mll(data, params_min, transform = TRUE, summed = TRUE)
+    q25 <- predped::mll(data, params_25, transform = TRUE, summed = TRUE)
+    q75 <- predped::mll(data, params_75, transform = TRUE, summed = TRUE)
+    max <- predped::mll(data, params_max, transform = TRUE, summed = TRUE)
     
     # Ideally, the mll of the generating parameters should be lower than the 
     # mll of other parameters. Test this assumption here.
@@ -86,6 +86,9 @@ testthat::test_that("Computing the MLL with conversion works", {
 })
 
 testthat::test_that("Likelihood R and Rcpp converge", {
+    ############################################################################
+    # SUMMED
+
     # Read in some test data. Of these, select only the first 100, as these 
     # already contain all necessary ingredients (social simulation)
     data <- readRDS(file.path("data", "data_mll.Rds"))
@@ -97,16 +100,45 @@ testthat::test_that("Likelihood R and Rcpp converge", {
 
     # Create test and reference and compare both across all datapoints. Here, 
     # we don't transform the parameters
-    ref <- predped::mll(data, params, transform = FALSE, cpp = FALSE)
-    tst <- predped::mll(data, params, transform = FALSE, cpp = TRUE)
+    ref <- predped::mll(data, params, transform = FALSE, cpp = FALSE, summed = TRUE)
+    tst <- predped::mll(data, params, transform = FALSE, cpp = TRUE, summed = TRUE)
 
     testthat::expect_equal(ref, tst)
 
     # And now do one where you do transform the parameters
     params <- predped::to_unbounded(params, predped::params_from_csv[["params_bounds"]])
 
-    ref <- predped::mll(data, params, transform = TRUE, cpp = FALSE)
-    tst <- predped::mll(data, params, transform = TRUE, cpp = TRUE)
+    ref <- predped::mll(data, params, transform = TRUE, cpp = FALSE, summed = TRUE)
+    tst <- predped::mll(data, params, transform = TRUE, cpp = TRUE, summed = TRUE)
+
+    testthat::expect_equal(ref, tst)
+
+
+
+    ############################################################################
+    # RAW
+
+    # Read in some test data. Of these, select only the first 100, as these 
+    # already contain all necessary ingredients (social simulation)
+    data <- readRDS(file.path("data", "data_mll.Rds"))
+    data <- data[1:100, ]
+
+    # Retrieve the parameters of the SocialBaselineEuropean
+    params <- predped::params_from_csv[["params_archetypes"]]
+    params <- params[params$name == "SocialBaselineEuropean", ]
+
+    # Create test and reference and compare both across all datapoints. Here, 
+    # we don't transform the parameters
+    ref <- predped::mll(data, params, transform = FALSE, cpp = FALSE, summed = FALSE)
+    tst <- predped::mll(data, params, transform = FALSE, cpp = TRUE, summed = FALSE)
+
+    testthat::expect_equal(ref, tst)
+
+    # And now do one where you do transform the parameters
+    params <- predped::to_unbounded(params, predped::params_from_csv[["params_bounds"]])
+
+    ref <- predped::mll(data, params, transform = TRUE, cpp = FALSE, summed = FALSE)
+    tst <- predped::mll(data, params, transform = TRUE, cpp = TRUE, summed = FALSE)
 
     testthat::expect_equal(ref, tst)
 })


### PR DESCRIPTION
Solving Issue #61, which asked for a feature to return raw likelihoods rather than only summed min-log-likelihoods through the `mll` function. Added the logical argument `summed` to either compute the former (`FALSE`) or the latter (`TRUE`). By default, it is `FALSE`.