### PR TITLE
Issue 63

### DIFF
--- a/R/route.R
+++ b/R/route.R
@@ -665,7 +665,7 @@ prune_edges <- function(objects, segments, coord_specific = NULL) {
 
     if(!is.null(coord_specific)) {
         if(length(coord_specific) != length(objects)) {
-            test_2 <- logical(length(objects))
+            test_2 <- logical(length(nrow(segments)))
         } else { 
             coord_intersection <- lapply(seq_along(coord_specific), 
                                          \(i) line_intersection(coord_specific[[i]], segments, return_all = TRUE) &
@@ -674,7 +674,7 @@ prune_edges <- function(objects, segments, coord_specific = NULL) {
             test_2 <- Reduce("|", coord_intersection)
         }
     } else {
-        test_2 <- logical(length(objects))
+        test_2 <- logical(length(nrow(segments)))
     }
 
     # I want to only retain those that do not intersect, meaning that the complete

--- a/R/route.R
+++ b/R/route.R
@@ -657,15 +657,21 @@ prune_edges <- function(objects, segments, coord_specific = NULL) {
     # of the objects that you intersect them with (in `all_intersections`) and
     # later checking only for these exceptions with an alternative set of 
     # objects (in `coord_intersection`)
-    all_intersections <- lapply(objects, 
-                                \(x) line_intersection(x, segments, return_all = TRUE) &
-                                     (out_object(x, segments[, 1:2]) & 
-                                      out_object(x, segments[, 3:4])))
-    test_1 <- Reduce("|", all_intersections)
+    if(is.null(coord_specific)) {
+        all_intersections <- lapply(objects, 
+                                    \(x) line_intersection(x, segments, return_all = TRUE))
 
-    if(!is.null(coord_specific)) {
+        test_1 <- Reduce("|", all_intersections)
+        test_2 <- logical(nrow(segments))
+    } else {
+        all_intersections <- lapply(objects, 
+                                    \(x) line_intersection(x, segments, return_all = TRUE) &
+                                         (out_object(x, segments[, 1:2]) & 
+                                          out_object(x, segments[, 3:4])))
+        test_1 <- Reduce("|", all_intersections)
+
         if(length(coord_specific) != length(objects)) {
-            test_2 <- logical(length(nrow(segments)))
+            test_2 <- logical(nrow(segments))
         } else { 
             coord_intersection <- lapply(seq_along(coord_specific), 
                                          \(i) line_intersection(coord_specific[[i]], segments, return_all = TRUE) &
@@ -673,8 +679,6 @@ prune_edges <- function(objects, segments, coord_specific = NULL) {
                                                in_object(objects[[i]], segments[, 3:4])))
             test_2 <- Reduce("|", coord_intersection)
         }
-    } else {
-        test_2 <- logical(length(nrow(segments)))
     }
 
     # I want to only retain those that do not intersect, meaning that the complete

--- a/tests/testthat/test_route.R
+++ b/tests/testthat/test_route.R
@@ -167,7 +167,7 @@ testthat::test_that("Evaluating which edges should be deleted works", {
                                                cost = cost[1:8]))
 
     # Do the test
-    tst <- predped:::evaluate_edges(segments, setting)
+    tst <- predped:::evaluate_edges(segments, setting, space_between = 0)
 
     testthat::expect_equal(tst$edges, ref$edges)
     testthat::expect_equal(tst$edges_with_coords, ref$edges_with_coords)

--- a/tests/testthat/test_simulate.R
+++ b/tests/testthat/test_simulate.R
@@ -86,7 +86,7 @@ testthat::test_that("Creating initial condition works", {
     agents_many <- predped::create_initial_condition(50, model, goal_number = 5, individual_differences = FALSE)
 
     testthat::expect_equal(length(agents_few), 3)
-    testthat::expect_equal(length(agents_many), 6)
+    testthat::expect_equal(length(agents_many), 5)
     testthat::expect_message(predped::create_initial_condition(50, model, goal_number = 5))
 
     # If you would ever want to visualize it during debugging


### PR DESCRIPTION
Fix of Issue #63. Solved the issue by forcing agents to always keep a line of sight with their next navigation point (originally only handled in utility, now elicits a "reroute").

Fix is a bit slow, so try to optimize this in Issue #51 (optimizing `prune_edges`).