### PR TITLE
Change `comment.char` in `read.table`

### DIFF
--- a/R/parameters.R
+++ b/R/parameters.R
@@ -219,7 +219,10 @@ load_parameters <- function(x = NULL,
     # Case: Other delimited files        
     } else {
         # Use read.table for this purpose
-        params <- utils::read.table(x, header = TRUE, sep = sep)
+        params <- utils::read.table(x, 
+                                    header = TRUE, 
+                                    sep = sep,
+                                    comment.char = "@")
     }
 
     # When parameters have been read in, we should check what their type is. 


### PR DESCRIPTION
Small fix in `utils::read.table`: Users can now use Hex-numbers to indicate colors in the parameter files.

Solves Issue #67