### PR TITLE
Issue 68: Reprise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ tmp/
 *.zip
 *.pdf
 *.out
+*.dll
 docs/*
 
 R/*_depr.R

--- a/R/moving_options.R
+++ b/R/moving_options.R
@@ -143,7 +143,7 @@ setMethod("moving_options", "agent", function(object,
 
     # If there are still cells free, check whether the goal can still be seen
     # or whether an agent should re-plan
-    if(!all(!check)){
+    if(!all(!check)) { 
         # Weird bug: running seesGoalOK_rcpp changes `check` or copy of `check`.
         # Keep copy of the opposite of `check` for later use
         opposite_check <- !check

--- a/R/moving_options.R
+++ b/R/moving_options.R
@@ -107,12 +107,15 @@ setMethod("moving_options", "agent", function(object,
     # immediately test whether cells are occupied by other agents instead of 
     # doing this check only later.
     # 
-    # You have to delete the current agent from this!
+    # Differentiate between a list that does contain the other agents 
+    # (slot in background) and a list that does not (obj). This distinction is 
+    # used later when checking the seeing of goals 
     ids <- sapply(agents(state), id)
     agents_minus_agent <- agents(state)[ids != id(object)]
 
+    obj <- objects(background)
     objects(background) <- append(objects(background), 
-                                  agents_minus_agent)
+                                  agents_minus_agent)   
 
     # Use the `free_cells` function to get all free cells to which the agent
     # might move. Specifically look at whether a cell lies within the background
@@ -138,7 +141,7 @@ setMethod("moving_options", "agent", function(object,
     # `overlap_with_object` only checks those cells that are free, the output
     # of this function can overwrite the local `check` variable without any
     # issues
-    if(!all(!check)){
+    if(!all(!check)) {
         # check <- m4ma::bodyObjectOK_rcpp(size(agent), centers, objects(background), check) # Original
         check <- overlap_with_objects(object, background, centers, check, cpp = FALSE)
         # check <- bodyObjectOK(size(object), centers, objects(background), as.vector(check))
@@ -151,7 +154,7 @@ setMethod("moving_options", "agent", function(object,
 
     # If there are still cells free, check whether the goal can still be seen
     # or whether an agent should re-plan
-    if(!all(!check)) { 
+    if(!all(!check)){
         # Weird bug: running seesGoalOK_rcpp changes `check` or copy of `check`.
         # Keep copy of the opposite of `check` for later use
         opposite_check <- !check
@@ -164,7 +167,8 @@ setMethod("moving_options", "agent", function(object,
         attr(goal_list[[1]], "i") <- 1
         state_dummy <- list(P = goal_list)
         
-        local_check <- m4ma::seesGoalOK_rcpp(1, objects(background), state_dummy, centers, check)
+        # local_check <- m4ma::seesGoalOK_rcpp(1, objects(background), state_dummy, centers, check)
+        local_check <- m4ma::seesGoalOK_rcpp(1, obj, state_dummy, centers, check)
 
         # Here, change `check` based on the results of the function. Importantly,
         # agent should still move even if it cannot see their goal (hence the

--- a/R/moving_options.R
+++ b/R/moving_options.R
@@ -125,6 +125,14 @@ setMethod("moving_options", "agent", function(object,
                        \(x) in_object(x, centers))
     check <- check & !Reduce("|", check_in)
 
+    # If something blocks the way in the previous column, then it should also 
+    # block the way on the columns. Note that we do this twice: Once here and 
+    # once after `overlap_with_objects`. Apparently, the model is sensitive to 
+    # both in their own right: Moving this check to once at the end changes how
+    # the pedestrians move around!
+    check[!check[,3],2] <- FALSE
+    check[!check[,2],1] <- FALSE
+
     # If there are still cells free, check whether an agent would intersect with
     # an object if it were to move to a given cell. Given that the function
     # `overlap_with_object` only checks those cells that are free, the output

--- a/R/plot.R
+++ b/R/plot.R
@@ -822,10 +822,7 @@ setMethod("transform_df", "background", function(object,
     # Step 3: Retain those entrances that fall within the specified bounds
     # of the shape
     entries <- do.call("rbind", entries)
-    entries <- entries[entries$x < limits[1, 2] &
-                       entries$x > limits[1, 1] &
-                       entries$y < limits[2, 2] &
-                       entries$y > limits[2, 1], ]
+    entries <- entries[in_object(object@shape, entries[, c("x", "y")]), ]
 
     # Return all points created here
     return(rbind(pts, 

--- a/R/update.R
+++ b/R/update.R
@@ -381,7 +381,7 @@ update_position <- function(agent,
         agent@cell_centers <- centers
 
         # Check for occlusions or blocked cells the agent cannot move to
-        check <- moving_options(agent, state, background, centers, cpp = cpp)
+        check <- moving_options(agent, state, background, centers, cpp = FALSE)
         
         # If there are no good options available, trigger a reroutening of the 
         # agent: This will create new path points and let the agent reorient. 

--- a/R/update.R
+++ b/R/update.R
@@ -381,7 +381,7 @@ update_position <- function(agent,
         agent@cell_centers <- centers
 
         # Check for occlusions or blocked cells the agent cannot move to
-        check <- moving_options(agent, state, background, centers, cpp = FALSE)
+        check <- moving_options(agent, state, background, centers, cpp = cpp)
         
         # If there are no good options available, trigger a reroutening of the 
         # agent: This will create new path points and let the agent reorient. 

--- a/src/moving_options.cpp
+++ b/src/moving_options.cpp
@@ -424,18 +424,7 @@ LogicalMatrix moving_options_rcpp(S4 agent,
                 local_check.begin()
             );
             check = converted_check;
-
-        // If the local check doesn't contain anything, we can base ourselves 
-        // upon the results of the check_vec that we created earlier. Note that 
-        // this check_vec is already accounted for in local_check as well
-        } else {
-            LogicalMatrix converted_check(
-                11, 
-                3, 
-                check_vec.begin()
-            );
-            check = converted_check;
-        }
+        } 
     }
 
     return check;

--- a/src/moving_options.cpp
+++ b/src/moving_options.cpp
@@ -328,7 +328,7 @@ LogicalMatrix moving_options_rcpp(S4 agent,
             centers, 
             check
         );
-        // // Make copy of check
+        // Make copy of check
         // LogicalMatrix check_vec = clone(check);
         // check_vec.attr("dim") = R_NilValue;
 

--- a/tests/testthat/test_moving_options.R
+++ b/tests/testthat/test_moving_options.R
@@ -492,15 +492,15 @@ testthat::test_that("Testing edge case; agent cannot cross border of an object",
                                                        cpp = TRUE)))
 
     testthat::expect_true(all(predped::moving_options(my_agent, 
-                                                       my_state, 
-                                                       my_background,
-                                                       inside, 
-                                                       cpp = FALSE)))
+                                                      my_state, 
+                                                      my_background,
+                                                      inside, 
+                                                      cpp = FALSE)))
     testthat::expect_true(all(predped::moving_options(my_agent, 
-                                                       my_state, 
-                                                       my_background,
-                                                       inside, 
-                                                       cpp = TRUE)))
+                                                      my_state, 
+                                                      my_background,
+                                                      inside, 
+                                                      cpp = TRUE)))
 
     testthat::expect_equal(predped::moving_options(my_agent, 
                                                    my_state, 
@@ -535,3 +535,80 @@ testthat::test_that("Testing edge case; agent cannot cross border of an object",
     #                       y = combo[, 2],
     #                       color = "green")
 })
+
+# Add attempted test: Problem is that when all seesGoalOK are FALSE, it will move
+# back to the initial check, which in this case is all TRUE. 
+#
+# TO DO: Check whether we can test this feature of the model anyway.
+# testthat::test_that(
+#     "Testing edge case: Can move everywhere, but won't see goal, R and Rcpp",
+#     {
+#         # Create a setting with only a single object
+#         my_setting <- predped::background(shape = predped::rectangle(center = c(0, 0), 
+#                                                                      size = c(10, 10)),
+#                                           objects = list(predped::rectangle(center = c(0, 0), 
+#                                                                             size = c(2, 2))))
+
+#         # Create a state (importantly, without the actual agent in there)
+#         my_state <- predped::state(iteration = 1, 
+#                                    setting = my_setting, 
+#                                    agents = list())
+        
+#         # Create a set of goals that may or may not be visible to the agent
+#         goals <- list(predped::goal(position = c(0, 1.05)),
+#                       predped::goal(position = c(1.05, 0)),
+#                       predped::goal(position = c(0, -1.05)),
+#                       predped::goal(position = c(-1.05, 0)))
+#         goals <- lapply(goals, 
+#                         function(x) {
+#                             x@path <- matrix(x@position, nrow = 1)
+#                             return(x)
+#                         })
+
+#         # Create an agent in the left-corner of the space. Will allow them to 
+#         # see the negative position goals, but not the others. Importantly, 
+#         # will be able to move anywhere with regards to not overlapping with 
+#         # objects: Any restrictions in moving_options comes from not seeing a 
+#         # goal
+#         my_agent <- predped::agent(center = c(-4, -4), 
+#                                    radius = 0.25,
+#                                    orientation = 45, 
+#                                    speed = 1.5)
+
+#         centers <- m4ma::c_vd(1:33, 
+#                               predped::position(my_agent),
+#                               predped::speed(my_agent),
+#                               predped::orientation(my_agent))
+
+#         # Create the reference
+#         ref <- c(FALSE, FALSE, TRUE, TRUE)
+
+#         # Loop over the different goals and do the required tests
+#         for(i in seq_along(goals)) {
+#             # Change the current goal of the agent
+#             my_agent@current_goal <- goals[[i]] 
+
+#             # Compute the moving options for the agent
+#             check <- predped::moving_options(my_agent, 
+#                                              my_state, 
+#                                              my_setting, 
+#                                              centers,
+#                                              cpp = FALSE)
+
+#         }
+
+#         # Visualize the situation
+#         # predped::plot(my_setting) +
+#         #     predped::plot(my_agent) + 
+#         #     ggplot2::annotate("point", 
+#         #                       x = sapply(goals, \(x) x@position[1]),
+#         #                       y = sapply(goals, \(x) x@position[2]),
+#         #                       size = 3, 
+#         #                       color = "cornflowerblue") +
+#         #     ggplot2::annotate("point", 
+#         #                       x = centers[, 1],
+#         #                       y = centers[, 2],
+#         #                       size = 1.5, 
+#         #                       color = "red")
+#     }
+# )


### PR DESCRIPTION
The previous fix introduced some unintended consequences, namely making the agents stop more often because they ran out of options. The problem could be traced back to an unsafe function of the `m4ma` package, overwriting previous values of a check of the moving options and, with this, introducing the bug we observed. 

Besides fixing this bug, I also made agents "see-through". This allows for an agent to still see their goal, even if another agent is standing in the way. This might be likened to object permanence: Even if another agent is standing in the way now, doesn't mean that one doesn't know where the goal would be if the agent were not there. This fix creates somewhat more realistic behavior.