### PR TITLE
Issue 90

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,7 +20,7 @@ jobs:
         config:
           - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          # - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: predped
 Type: Package
 Title: Interface to Minds for Mobile Agents
-Version: 0.1.1
+Version: 0.1.2
 Date: 2026-02-05
 Description: 
     Helper functions to allow simulating pedestrian flow with the Minds for Mobile Agents (M4MA) pedestrian model. 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: predped
 Type: Package
 Title: Interface to Minds for Mobile Agents
-Version: 0.1.0
-Date: 2026-01-07
+Version: 0.1.1
+Date: 2026-02-05
 Description: 
     Helper functions to allow simulating pedestrian flow with the Minds for Mobile Agents (M4MA) pedestrian model. 
     Contains functions to generate environments, adapt pedestrian characteristics, and allow for a wide range of 
@@ -49,7 +49,7 @@ Imports:
     MASS,
     matrixStats
 LinkingTo: Rcpp, RcppArmadillo
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Collate:
     'predped-package.R'
     'RcppExports.R'

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -284,7 +284,7 @@ setMethod("simulate", "predped", function(object,
     if((is.null(initial_agents) & is.null(initial_condition)) & !is.null(initial_number_agents)) {
         initial_agents <- create_initial_condition(initial_number_agents,
                                                    object,
-                                                   goal_number = goal_number[1:initial_number_agents],
+                                                   goal_number = goal_number[1],
                                                    goal_duration = goal_duration,
                                                    middle_edge = middle_edge,
                                                    standing_start = standing_start,

--- a/src/general.cpp
+++ b/src/general.cpp
@@ -70,7 +70,7 @@ LogicalVector line_line_intersection_rcpp(NumericMatrix segments_1,
                 u = -u;
             }
 
-            result[i * n + j] = (0 < t) && (t <= abs(t_max)) && (0 < u) && (u <= abs(u_max)); 
+            result[i * n + j] = (0 < t) && (t <= fabs(t_max)) && (0 < u) && (u <= fabs(u_max)); 
         }
     }
     

--- a/src/moving_options.cpp
+++ b/src/moving_options.cpp
@@ -108,7 +108,7 @@ Rcpp::NumericMatrix compute_centers_rcpp(Rcpp::S4 agent,
     for(int i = 0; i < velocities.length(); i++) {
         // Define a slowing factor that depends on the turning angle or change in
         // direction
-        slow = 1. - b * pow(sin(abs(angles[i]) / 2), a);
+        slow = 1. - b * pow(sin(fabs(angles[i]) / 2), a);
 
         // Adjust the velocity of the agent
         velocity = speed * slow * velocities[i] * time_step;

--- a/src/utility_model.cpp
+++ b/src/utility_model.cpp
@@ -495,7 +495,7 @@ NumericVector gc_utility_rcpp(double a_group_centroid,
     NumericVector V(cell_distances.length());
     for(int i = 0; i < cell_distances.length(); i++) {
         if(optimal[i]) {
-            difference = std::abs(cell_distances[i] - optimal_distance);
+            difference = std::fabs(cell_distances[i] - optimal_distance);
             V[i] -= b_group_centroid * std::pow(difference, a_group_centroid);
         }
     }

--- a/src/utility_model.cpp
+++ b/src/utility_model.cpp
@@ -495,7 +495,7 @@ NumericVector gc_utility_rcpp(double a_group_centroid,
     NumericVector V(cell_distances.length());
     for(int i = 0; i < cell_distances.length(); i++) {
         if(optimal[i]) {
-            difference = std::fabs(cell_distances[i] - optimal_distance);
+            difference = fabs(cell_distances[i] - optimal_distance);
             V[i] -= b_group_centroid * std::pow(difference, a_group_centroid);
         }
     }

--- a/tests/testthat/test_moving_options.R
+++ b/tests/testthat/test_moving_options.R
@@ -918,7 +918,7 @@ testthat::test_that(
 
                 tmp[[idx]] <- c(range(diff), dummy@center)
 
-                tst[idx] <- all(abs(diff) < 1e-2)
+                tst[idx] <- all(abs(diff) < 1e-4)
                 idx <- idx + 1
             }
         }


### PR DESCRIPTION
Fixes for Issues #87 and #90. 

For Issue #87, the problem originated in a wrong use of the `abs` function in C++. I assumed `abs` worked for floats, but have since learned that the `fabs` function should be used instead.

For Issue #90, it seemed that I used the first `initial_number_agents` values in the `goal_number` vector when creating an initial condition in `simulate`. However, `goal_number` only contained a sufficient number of values for each iteration of the simulation, an artifact still stemming from the days in which only a single agent could enter at each iteration step. This oversight led to the presence of `NA`s in the assignment of goals, and to the error reported in Issue #90. 