### PR TITLE
Issue 96

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: predped
 Type: Package
 Title: Interface to Minds for Mobile Agents
-Version: 0.2.0
+Version: 0.2.2
 Date: 2026-02-05
 Description: 
     Helper functions to allow simulating pedestrian flow with the Minds for Mobile Agents (M4MA) pedestrian model. 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
     person("Niels", 
            "Vanhasbroeck", 
            email = "niels.vanhasbroeck@gmail.com",
-           comment = c(ORCID = 0000-0002-7423-0090),
+           comment = c(ORCID = "0000-0002-7423-0090"),
            role = c("aut", "cre")), 
     person("Malte", 
            "Lüken",

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -1136,13 +1136,24 @@ create_initial_condition <- function(agent_number,
                                           length.out = n_agents_fit[i])))
     alternatives <- do.call("rbind", alternatives)
 
-
     # Create a dummy agent. This will allow for faster generation of the initial
     # condition, as changing an agent's characteristics is faster than the 
     # generation of one
     dummy <- agent(center = c(0, 0), radius = 0.25)
     dummy_big <- dummy
     radius(dummy_big) <- 2 * max_size
+
+    # Remove all alternatives that would end with an overlap with the objects
+    # in the space.
+    idx <- lapply(
+        objects(model@setting),
+        function(x) x |>
+            enlarge(extension = space_between * max_size) |>
+            in_object(alternatives)
+    )
+    idx <- do.call("cbind", idx) |>
+        rowSums()
+    alternatives <- alternatives[idx == 0, ]
 
     # Loop over the agents and use `add_agent` to create an initial agent. Note
     # that we have to change some of the characteristics of these agents,
@@ -1151,6 +1162,15 @@ create_initial_condition <- function(agent_number,
     group_number <- 0
     agents <- list()
     for(i in seq_len(agent_number)) {
+        # Check whether we can still add some agents to the list based on the 
+        # positions that are left.
+        if(nrow(alternatives) == 0) {
+            message(paste0("Couldn't add any new agents after ",
+                           length(agents),
+                           " due to crowdiness."))
+            break
+        }
+
         # Sample a random position on which the agent will stand and adjust the
         # dummy
         idx <- sample(1:nrow(alternatives), 1)
@@ -1200,15 +1220,6 @@ create_initial_condition <- function(agent_number,
 
         idx <- out_object(dummy_big, alternatives)
         alternatives <- alternatives[idx, ]
-
-        # Check whether we can still add some agents to the list based on the 
-        # positions that are left.
-        if(nrow(alternatives) == 0) {
-            message(paste0("Couldn't add any new agents after ",
-                           length(agents),
-                           " due to crowdiness."))
-            break
-        }
     }
 
     return(agents)

--- a/man/predped-package.Rd
+++ b/man/predped-package.Rd
@@ -19,7 +19,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Niels Vanhasbroeck \email{niels.vanhasbroeck@gmail.com} (-7515)
+\strong{Maintainer}: Niels Vanhasbroeck \email{niels.vanhasbroeck@gmail.com} (\href{https://orcid.org/0000-0002-7423-0090}{ORCID})
 
 Authors:
 \itemize{

--- a/tests/testthat/test_simulate.R
+++ b/tests/testthat/test_simulate.R
@@ -95,7 +95,7 @@ testthat::test_that("Creating initial condition works", {
         suppressMessages()
 
     testthat::expect_equal(length(agents_few), 3)
-    testthat::expect_equal(length(agents_many), 7)
+    testthat::expect_equal(length(agents_many), 5)
     testthat::expect_message(predped::create_initial_condition(50, model, goal_number = 5))
 
     # If you would ever want to visualize it during debugging


### PR DESCRIPTION
Fix Issue #96, where agents could be placed (at least partially) inside of objects when using the `create_initial_condition` function. I added a check for overlap with these objects at the start of the generation process, ensuring that agents cannot fall within a range `space_between * max_size` of the objects, where `space_between` is an argument provided in the `create_initial_condition` function and `max_size` is the maximal radius of an agent. 