### PR TITLE
Optimize flow

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: predped
 Type: Package
 Title: Interface to Minds for Mobile Agents
-Version: 0.4.0
+Version: 0.4.1
 Date: 2026-02-05
 Description: 
     Helper functions to allow simulating pedestrian flow with the Minds for Mobile Agents (M4MA) pedestrian model. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# predped v0.4.1
+
+Minor bugs were solved in this version:
+
+- Changed how waiting is handled, allowing agents to temporarily move out of the way whenever multiple agents are blocking each other's access to their goals, preventing them from completing the goals;
+- Make agents the `group_representative` by default, allowing users to specify their own agents without having to worry about this attribute.
+
+
+
 # predped v0.4.0
 
 - Initial release

--- a/R/agent.R
+++ b/R/agent.R
@@ -145,7 +145,7 @@ agent <- setClass("agent",
 #' goal is not included in this list. Defaults to an empty list.
 #' @param group_representative Logical denoting whether the agent is the representative of 
 #' their group. The representative is the only one in the group that completes the group 
-#' goals, hence also leading the group towards the group goals. Defaults to \code{FALSE}.
+#' goals, hence also leading the group towards the group goals. Defaults to \code{TRUE}.
 #' @param individual_goals List of goals the agent has to achieve that are not shared with their group.
 #' These will be completes after the agent's group goals are completed. Defaults to an empty list.
 #' @param parameters Dataframe containing the values of the parameters for the 
@@ -206,7 +206,7 @@ setMethod("initialize", "agent", function(.Object,
                                           group = 0,
                                           current_group_goal = NULL,
                                           group_goals = list(),
-                                          group_representative = FALSE,
+                                          group_representative = TRUE,
                                           individual_goals = list(),
                                           status = "move",
                                           waiting_counter = 0,

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -808,7 +808,7 @@ add_group <- function(model,
         # Match the leader's starting orientation so they walk into the room smoothly
         orientation(tmp_agent) <- orientation(agents[[1]])
 
-        # Ensures they are followers (should be default anyways)
+        # Ensures they are followers
         group_representative(tmp_agent) <- FALSE
 
         # Add the agent to the list

--- a/R/update.R
+++ b/R/update.R
@@ -993,27 +993,30 @@ update_goal <- function(agent,
         # again
         if(!any(blocking_agents)) {
             agent@extra_objects[["stuck_count"]] <- 0L
-            status(agent) <- "reorient"
+
             if (nrow(current_goal(agent)@path) > 0) {
                 status(agent) <- "reorient"
+
             } else {
                 status(agent) <- "plan"
             }
-        }
 
         # If counter is low enough, the agent will have to reroute his approach
         # to the goal. To make sure agents don't get stuck easily, let them
         # pursue another goal and come back later. Only applicable if the agent
         # still has other goals to pursue
-        if(waiting_counter(agent) < 0 & status(agent) != "move" & adaptive_goal_sorting) {
+        } else if(waiting_counter(agent) < 0) {
             # First check whether the agent is the group representative (always
             # the case when the agent is running around as an individual). If 
             # not, they cannot take action and have to wait for the representative
             # to make a choice regarding goal updating
             if(!group_representative(agent)) {
                 waiting_counter(agent) <- 5 # Keep waiting patiently
+
             } else {
-                if(length(goals(agent)) != 0) {
+                # If you can adaptively sort the goals, then change some goals 
+                # around.
+                if(length(goals(agent)) != 0 & adaptive_goal_sorting) {
                     goals(agent) <- append(current_goal(agent), 
                                            goals(agent))
                     current_goal(agent) <- goals(agent)[[2]]
@@ -1024,12 +1027,40 @@ update_goal <- function(agent,
                     group_goals(agent) <- goals(agent)
                     
                     status(agent) <- "plan"
+
+                # If not, then we need another way out of this conundrum. We 
+                # do this by letting the agent move away for a little bit and
+                # then coming back.
                 } else {
-                    if (nrow(current_goal(agent)@path) > 0) {
-                        status(agent) <- "reorient"
+                    # Add the current goal to the goal stack
+                    goals(agent) <- append(current_goal(agent), 
+                                           goals(agent))
+
+                    # Select a path point that is far enough so that you move 
+                    # outside of the range for interacting with a goal
+                    distances <- 
+                        (precomputed_edges$nodes$X - position(agent)[1])^2 + 
+                        (precomputed_edges$nodes$Y - position(agent)[2])^2
+                    idx <- distances >= close_enough + 2
+                    idx <- which(distances == min(distances[idx]))[1]
+
+                    if(!is.na(idx)) {
+                        new_position <- c(precomputed_edges$nodes$X[idx],
+                                          precomputed_edges$nodes$Y[idx])
                     } else {
-                        status(agent) <- "plan"
+                        distances <- 
+                            (position(agent)[1] - exits[,1])^2 + 
+                            (position(agent)[2] - exits[,2])^2
+                        new_position <- as.numeric(exits[which.min(distances), ])
                     }
+
+                    # Add a conflict resolution goal that dictates agents moving 
+                    # out of the way of others temporarily whenever they waited
+                    # for a long time
+                    current_goal(agent) <- goal(id = "goal conflict resolution",
+                                                position = new_position,
+                                                counter = 1)
+                    status(agent) <- "plan"
                 }
             }
         }

--- a/README.Rmd
+++ b/README.Rmd
@@ -14,8 +14,8 @@ knitr::opts_chunk$set(
 ```
 
 <!-- badges: start --> 
-[![version](https://img.shields.io/badge/version-v0.4.0-blue)](https://github.com/ndpvh/predped/releases)
-[![documentation](https://img.shields.io/badge/documentation-v0.4.0-blue)](https://ndpvh.github.io/predped)
+[![version](https://img.shields.io/badge/version-v0.4.1-blue)](https://github.com/ndpvh/predped/releases)
+[![documentation](https://img.shields.io/badge/documentation-v0.4.1-blue)](https://ndpvh.github.io/predped)
 [![build](https://github.com/ndpvh/predped/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ndpvh/predped/actions/workflows/R-CMD-check.yaml)
 [![coverage](https://codecov.io/gh/ndpvh/predped/graph/badge.svg)](https://app.codecov.io/gh/ndpvh/predped)
 [![license: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 <!-- badges: start -->
 
-[![version](https://img.shields.io/badge/version-v0.4.0-blue)](https://github.com/ndpvh/predped/releases)
-[![documentation](https://img.shields.io/badge/documentation-v0.4.0-blue)](https://ndpvh.github.io/predped)
+[![version](https://img.shields.io/badge/version-v0.4.1-blue)](https://github.com/ndpvh/predped/releases)
+[![documentation](https://img.shields.io/badge/documentation-v0.4.1-blue)](https://ndpvh.github.io/predped)
 [![build](https://github.com/ndpvh/predped/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ndpvh/predped/actions/workflows/R-CMD-check.yaml)
 [![coverage](https://codecov.io/gh/ndpvh/predped/graph/badge.svg)](https://app.codecov.io/gh/ndpvh/predped)
 [![license: GPL

--- a/man/initialize-agent.Rd
+++ b/man/initialize-agent.Rd
@@ -16,7 +16,7 @@
   group = 0,
   current_group_goal = NULL,
   group_goals = list(),
-  group_representative = FALSE,
+  group_representative = TRUE,
   individual_goals = list(),
   status = "move",
   waiting_counter = 0,
@@ -66,7 +66,7 @@ goal is not included in this list. Defaults to an empty list.}
 
 \item{group_representative}{Logical denoting whether the agent is the representative of 
 their group. The representative is the only one in the group that completes the group 
-goals, hence also leading the group towards the group goals. Defaults to \code{FALSE}.}
+goals, hence also leading the group towards the group goals. Defaults to \code{TRUE}.}
 
 \item{individual_goals}{List of goals the agent has to achieve that are not shared with their group.
 These will be completes after the agent's group goals are completed. Defaults to an empty list.}


### PR DESCRIPTION
Solve some minor bugs and increase pedestrian flow. Specifically:

- Changed how waiting is handled, allowing agents to temporarily move out of the way whenever multiple agents are blocking each other's access to their goals, preventing them from completing the goals;
- Make agents the `group_representative` by default, allowing users to specify their own agents without having to worry about this attribute.

Updated version to 0.4.1 